### PR TITLE
Compile on Rust 1.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,12 @@ license = "MIT"
 [features]
 snappy = ["leveldb-sys/snappy"]
 
+[dependencies]
+libc = "*"
+
 [dependencies.leveldb-sys]
 path = "leveldb-sys"
 version = "0.0.2"
+
+[dev-dependencies]
+tempdir = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "leveldb-rs"
-version = "0.0.4"
+version = "0.0.5"
 authors = ["Andrew Dunham <andrew@du.nham.ca>"]
 
 description = "Bindings to the LevelDB key/value storage library (https://github.com/google/leveldb)"
@@ -18,7 +18,7 @@ libc = "*"
 
 [dependencies.leveldb-sys]
 path = "leveldb-sys"
-version = "0.0.2"
+version = "0.0.3"
 
 [dev-dependencies]
 tempdir = "0.3.0"

--- a/leveldb-sys/Cargo.toml
+++ b/leveldb-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leveldb-sys"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Andrew Dunham <andrew@du.nham.ca>"]
 
 description = "FFI bindings to LevelDB"


### PR DESCRIPTION
Collected fixed to build leveldb-sys and leveldb-rs on Rust 1.1.0. Passes all tests.